### PR TITLE
Added debtYears in JPA schema + bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ Technologies:
 
 ---------------------------
 Created and authored by Matthew Gabriel
+Discounts calculated with data provided by [Financial Modeling Prep](https://financialmodelingprep.com/developer/docs/)

--- a/src/main/java/com/facts/financial_facts_service/constants/interfaces/Queries.java
+++ b/src/main/java/com/facts/financial_facts_service/constants/interfaces/Queries.java
@@ -2,22 +2,6 @@ package com.facts.financial_facts_service.constants.interfaces;
 
 public interface Queries {
 
-    String getAllActiveSimpleDiscounts =
-            "select a.cik, " +
-            "a.symbol, " +
-            "a.name, " +
-            "a.active, " +
-            "b.ratio_price, " +
-            "c.sale_price AS \"ttmSalePrice\", " +
-            "d.sale_price AS \"tfySalePrice\", " +
-            "e.sale_price AS \"ttySalePrice\" " +
-            "FROM discount a,  " +
-            "benchmark_ratio_price b, " +
-            "ttm_price_data c, " +
-            "tfy_price_data d, " +
-            "tty_price_data e " +
-            "WHERE a.cik=b.cik AND a.cik=c.cik AND a.cik=d.cik AND a.cik=e.cik AND a.active=true;";
-
     String getAllSimpleDiscounts =
             "select a.cik, " +
             "a.symbol, " +

--- a/src/main/java/com/facts/financial_facts_service/controllers/DiscountController.java
+++ b/src/main/java/com/facts/financial_facts_service/controllers/DiscountController.java
@@ -47,7 +47,7 @@ public class DiscountController implements Constants {
     @GetMapping("/bulkSimpleDiscounts")
     public CompletableFuture<ResponseEntity<List<SimpleDiscount>>> getBulkSimpleDiscounts() {
         logger.info("In discount controller getting bulk simple discounts");
-        return discountService.getBulkSimpleDiscounts(false)
+        return discountService.getBulkSimpleDiscounts()
             .flatMap(cikList -> {
                 logger.info("Fetch complete for bulk simple discounts");
                 return Mono.just(new ResponseEntity<>(cikList, HttpStatus.OK));

--- a/src/main/java/com/facts/financial_facts_service/datafetcher/DataFetcher.java
+++ b/src/main/java/com/facts/financial_facts_service/datafetcher/DataFetcher.java
@@ -27,7 +27,7 @@ public class DataFetcher {
         logger.info("In DataFetcher getting identities and discounts using {} and includeDiscounts {}",
                 request, includeDiscounts);
         return includeDiscounts
-            ? Mono.zip(identityService.getBulkIdentities(request), discountService.getBulkSimpleDiscounts(true))
+            ? Mono.zip(identityService.getBulkIdentities(request), discountService.getBulkSimpleDiscounts())
                 .flatMap(tuple -> {
                     logger.info("In datafetcher returning bulk identities and discounts for request {}", request);
                     return Mono.just(new IdentitiesAndDiscounts(tuple.getT1(), tuple.getT2()));

--- a/src/main/java/com/facts/financial_facts_service/entities/discount/Discount.java
+++ b/src/main/java/com/facts/financial_facts_service/entities/discount/Discount.java
@@ -1,5 +1,6 @@
 package com.facts.financial_facts_service.entities.discount;
 
+import com.facts.financial_facts_service.entities.discount.interfaces.Copyable;
 import com.facts.financial_facts_service.entities.discount.models.benchmarkRatioPrice.BenchmarkRatioPrice;
 import com.facts.financial_facts_service.entities.discount.models.stickerPrice.StickerPrice;
 import jakarta.persistence.CascadeType;
@@ -28,7 +29,7 @@ import static com.facts.financial_facts_service.constants.interfaces.Constants.C
 @NoArgsConstructor(force = true)
 @ToString
 @Table(name = "discount")
-public class Discount {
+public class Discount implements Copyable<Discount> {
 
     @Id
     @NonNull
@@ -55,5 +56,16 @@ public class Discount {
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "cik")
     private StickerPrice stickerPrice;
+
+    @Override
+    public void copy(Discount update) {
+        this.cik = update.getCik();
+        this.symbol = update.getSymbol();
+        this.name = update.getName();
+        this.lastUpdated = LocalDate.now();
+        this.active = update.getActive();
+        this.benchmarkRatioPrice.copy(update.getBenchmarkRatioPrice());
+        this.stickerPrice.copy(update.getStickerPrice());
+    }
 
 }

--- a/src/main/java/com/facts/financial_facts_service/entities/discount/interfaces/Copyable.java
+++ b/src/main/java/com/facts/financial_facts_service/entities/discount/interfaces/Copyable.java
@@ -1,0 +1,8 @@
+package com.facts.financial_facts_service.entities.discount.interfaces;
+
+
+public interface Copyable<T> {
+
+    void copy(T update);
+
+}

--- a/src/main/java/com/facts/financial_facts_service/entities/discount/models/PeriodicData.java
+++ b/src/main/java/com/facts/financial_facts_service/entities/discount/models/PeriodicData.java
@@ -1,6 +1,5 @@
 package com.facts.financial_facts_service.entities.discount.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;

--- a/src/main/java/com/facts/financial_facts_service/entities/discount/models/benchmarkRatioPrice/BenchmarkRatioPrice.java
+++ b/src/main/java/com/facts/financial_facts_service/entities/discount/models/benchmarkRatioPrice/BenchmarkRatioPrice.java
@@ -1,6 +1,6 @@
 package com.facts.financial_facts_service.entities.discount.models.benchmarkRatioPrice;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.facts.financial_facts_service.entities.discount.interfaces.Copyable;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -16,7 +16,7 @@ import lombok.Setter;
 @Setter
 @Table(name = "benchmark_ratio_price")
 @JsonIgnoreProperties(value = { "cik" }, allowSetters = true)
-public class BenchmarkRatioPrice {
+public class BenchmarkRatioPrice implements Copyable<BenchmarkRatioPrice> {
 
     @Id
     private String cik;
@@ -26,5 +26,12 @@ public class BenchmarkRatioPrice {
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "cik")
     private BenchmarkRatioPriceInput input;
+
+    @Override
+    public void copy(BenchmarkRatioPrice update) {
+        this.cik = update.getCik();
+        this.ratioPrice = update.getRatioPrice();
+        this.input.copy(update.getInput());
+    }
 
 }

--- a/src/main/java/com/facts/financial_facts_service/entities/discount/models/benchmarkRatioPrice/BenchmarkRatioPriceInput.java
+++ b/src/main/java/com/facts/financial_facts_service/entities/discount/models/benchmarkRatioPrice/BenchmarkRatioPriceInput.java
@@ -1,6 +1,6 @@
 package com.facts.financial_facts_service.entities.discount.models.benchmarkRatioPrice;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.facts.financial_facts_service.entities.discount.interfaces.Copyable;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Setter
 @Table(name = "benchmark_ratio_price_input")
 @JsonIgnoreProperties(value = { "cik" }, allowSetters = true)
-public class BenchmarkRatioPriceInput {
+public class BenchmarkRatioPriceInput implements Copyable<BenchmarkRatioPriceInput> {
 
     @Id
     private String cik;
@@ -25,5 +25,14 @@ public class BenchmarkRatioPriceInput {
     private Long sharesOutstanding;
 
     private Double psBenchmarkRatio;
+
+    @Override
+    public void copy(BenchmarkRatioPriceInput update) {
+        this.cik = update.getCik();
+        this.industry = update.getIndustry();
+        this.ttmRevenue = update.getTtmRevenue();
+        this.sharesOutstanding = update.getSharesOutstanding();
+        this.psBenchmarkRatio = update.getPsBenchmarkRatio();
+    }
 
 }

--- a/src/main/java/com/facts/financial_facts_service/entities/discount/models/stickerPrice/StickerPrice.java
+++ b/src/main/java/com/facts/financial_facts_service/entities/discount/models/stickerPrice/StickerPrice.java
@@ -1,5 +1,6 @@
 package com.facts.financial_facts_service.entities.discount.models.stickerPrice;
 
+import com.facts.financial_facts_service.entities.discount.interfaces.Copyable;
 import com.facts.financial_facts_service.entities.discount.models.stickerPrice.trailingPriceData.TfyPriceData;
 import com.facts.financial_facts_service.entities.discount.models.stickerPrice.trailingPriceData.TtmPriceData;
 import com.facts.financial_facts_service.entities.discount.models.stickerPrice.trailingPriceData.TtyPriceData;
@@ -19,7 +20,7 @@ import lombok.Setter;
 @Setter
 @Table(name = "sticker_price")
 @JsonIgnoreProperties(value = { "cik" }, allowSetters = true)
-public class StickerPrice {
+public class StickerPrice implements Copyable<StickerPrice> {
 
     @Id
     private String cik;
@@ -40,4 +41,12 @@ public class StickerPrice {
     @JoinColumn(name = "cik")
     private StickerPriceInput input;
 
+    @Override
+    public void copy(StickerPrice update) {
+        this.cik = update.getCik();
+        this.ttmPriceData.copy(update.getTtmPriceData());
+        this.tfyPriceData.copy(update.getTfyPriceData());
+        this.ttyPriceData.copy(update.getTtyPriceData());
+        this.input.copy(update.getInput());
+    }
 }

--- a/src/main/java/com/facts/financial_facts_service/entities/discount/models/stickerPrice/StickerPriceInput.java
+++ b/src/main/java/com/facts/financial_facts_service/entities/discount/models/stickerPrice/StickerPriceInput.java
@@ -1,5 +1,7 @@
 package com.facts.financial_facts_service.entities.discount.models.stickerPrice;
 
+import com.facts.financial_facts_service.entities.discount.interfaces.Copyable;
+import com.facts.financial_facts_service.entities.discount.models.PeriodicData;
 import com.facts.financial_facts_service.entities.discount.models.stickerPrice.types.AnnualBVPS;
 import com.facts.financial_facts_service.entities.discount.models.stickerPrice.types.AnnualEPS;
 import com.facts.financial_facts_service.entities.discount.models.stickerPrice.types.AnnualEquity;
@@ -13,6 +15,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
@@ -24,30 +27,60 @@ import java.util.List;
 @Setter
 @Table(name = "sticker_price_input")
 @JsonIgnoreProperties(value = { "cik" }, allowSetters = true)
-public class StickerPriceInput {
+public class StickerPriceInput implements Copyable<StickerPriceInput> {
 
     @Id
     private String cik;
 
+    private Double debtYears;
+
+    @OrderBy("announced_date ASC")
     @OneToMany(mappedBy = "cik", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<AnnualBVPS> annualBVPS;
 
+    @OrderBy("announced_date ASC")
     @OneToMany(mappedBy = "cik", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<AnnualPE> annualPE;
 
+    @OrderBy("announced_date ASC")
     @OneToMany(mappedBy = "cik", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<AnnualEPS> annualEPS;
 
+    @OrderBy("announced_date ASC")
     @OneToMany(mappedBy = "cik", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<AnnualROIC> annualROIC;
 
+    @OrderBy("announced_date ASC")
     @OneToMany(mappedBy = "cik", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<AnnualEquity> annualEquity;
 
+    @OrderBy("announced_date ASC")
     @OneToMany(mappedBy = "cik", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<AnnualRevenue> annualRevenue;
 
+    @OrderBy("announced_date ASC")
     @OneToMany(mappedBy = "cik", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<AnnualOperatingCashFlow> annualOperatingCashFlow;
 
+    @Override
+    public void copy(StickerPriceInput update) {
+        this.cik = update.getCik();
+        this.debtYears = update.getDebtYears();
+        this.replacePeriodicData(update);
+    }
+
+    private <T extends PeriodicData> void replacePeriodicData(StickerPriceInput update) {
+        updatePeriodicData(this.annualBVPS, update.getAnnualBVPS());
+        updatePeriodicData(this.annualPE, update.getAnnualPE());
+        updatePeriodicData(this.annualEPS, update.getAnnualEPS());
+        updatePeriodicData(this.annualROIC, update.getAnnualROIC());
+        updatePeriodicData(this.annualEquity, update.getAnnualEquity());
+        updatePeriodicData(this.annualRevenue, update.getAnnualRevenue());
+        updatePeriodicData(this.annualOperatingCashFlow, update.getAnnualOperatingCashFlow());
+    }
+
+    private <T extends PeriodicData> void updatePeriodicData(List<T> current, List<T> update) {
+        current.clear();
+        current.addAll(update);
+    }
 }

--- a/src/main/java/com/facts/financial_facts_service/entities/discount/models/stickerPrice/trailingPriceData/AbstractTrailingPriceData.java
+++ b/src/main/java/com/facts/financial_facts_service/entities/discount/models/stickerPrice/trailingPriceData/AbstractTrailingPriceData.java
@@ -1,6 +1,7 @@
 package com.facts.financial_facts_service.entities.discount.models.stickerPrice.trailingPriceData;
 
 
+import com.facts.financial_facts_service.entities.discount.interfaces.Copyable;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Id;
@@ -12,7 +13,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @JsonIgnoreProperties(value = { "cik" }, allowSetters = true)
-public abstract class AbstractTrailingPriceData {
+public abstract class AbstractTrailingPriceData implements Copyable<AbstractTrailingPriceData> {
 
     @Id
     private String cik;
@@ -20,5 +21,12 @@ public abstract class AbstractTrailingPriceData {
     private Double stickerPrice;
 
     private Double salePrice;
+
+    @Override
+    public void copy(AbstractTrailingPriceData update) {
+        this.cik = update.getCik();
+        this.stickerPrice = update.getStickerPrice();
+        this.salePrice = update.getSalePrice();
+    }
 
 }

--- a/src/main/java/com/facts/financial_facts_service/repositories/DiscountRepository.java
+++ b/src/main/java/com/facts/financial_facts_service/repositories/DiscountRepository.java
@@ -15,7 +15,4 @@ public interface DiscountRepository extends JpaRepository<Discount, String>, Que
     @Query(value = getAllSimpleDiscounts, nativeQuery = true)
     List<SimpleDiscount> findAllSimpleDiscounts();
 
-    @Query(value = getAllActiveSimpleDiscounts, nativeQuery = true)
-    List<SimpleDiscount> findAllActiveSimpleDiscounts();
-
 }

--- a/src/main/resources/static/api-docs.yaml
+++ b/src/main/resources/static/api-docs.yaml
@@ -112,7 +112,8 @@ Deployment of new features is seamless with an AWS Pipeline configured to using 
   <li>AWS CodeDeploy</li>
 </ul>
 
-Created and authored by Matthew Gabriel"
+Created and authored by Matthew Gabriel<br>
+Discounts calculated with data provided by <a href=\"https://financialmodelingprep.com/developer/docs/\">Financial Modeling Prep</a>"
 version: "1.0"
 paths:
   /v1/discount:
@@ -550,6 +551,9 @@ components:
     StickerPriceInput:
       type: object
       properties:
+        debtYears:
+          type: number
+          format: double
         annualBVPS:
           type: array
           items:

--- a/src/test/java/com/facts/financial_facts_service/controllers/DiscountControllerTest.java
+++ b/src/test/java/com/facts/financial_facts_service/controllers/DiscountControllerTest.java
@@ -110,10 +110,10 @@ public class DiscountControllerTest implements TestConstants {
         @Test
         public void testGetBulkSimpleDiscountsSuccess() throws ExecutionException, InterruptedException {
             SimpleDiscount simpleDiscount = mock(SimpleDiscount.class);
-            when(discountService.getBulkSimpleDiscounts(false))
+            when(discountService.getBulkSimpleDiscounts())
                     .thenReturn(Mono.just(List.of(simpleDiscount)));
             ResponseEntity<List<SimpleDiscount>> actual = discountController.getBulkSimpleDiscounts().get();
-            verify(discountService).getBulkSimpleDiscounts(false);
+            verify(discountService).getBulkSimpleDiscounts();
             assertNotNull(actual.getBody());
             assertEquals(1, actual.getBody().size());
             assertEquals(simpleDiscount, actual.getBody().get(0));

--- a/src/test/java/com/facts/financial_facts_service/datafetcher/DataFetcherTest.java
+++ b/src/test/java/com/facts/financial_facts_service/datafetcher/DataFetcherTest.java
@@ -3,11 +3,9 @@ package com.facts.financial_facts_service.datafetcher;
 import com.facts.financial_facts_service.constants.TestConstants;
 import com.facts.financial_facts_service.datafetcher.projections.SimpleDiscount;
 import com.facts.financial_facts_service.datafetcher.records.IdentitiesAndDiscounts;
-import com.facts.financial_facts_service.entities.facts.Facts;
 import com.facts.financial_facts_service.entities.identity.Identity;
 import com.facts.financial_facts_service.entities.identity.models.BulkIdentitiesRequest;
 import com.facts.financial_facts_service.services.DiscountService;
-import com.facts.financial_facts_service.services.FactsService;
 import com.facts.financial_facts_service.services.identity.IdentityService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -54,11 +52,11 @@ public class DataFetcherTest implements TestConstants {
             List<Identity> identityList = List.of(identity);
             when(identityService.getBulkIdentities(request)).thenReturn(Mono.just(identityList));
             SimpleDiscount simpleDiscount = mock(SimpleDiscount.class);
-            when(discountService.getBulkSimpleDiscounts(true))
+            when(discountService.getBulkSimpleDiscounts())
                     .thenReturn(Mono.just(List.of(simpleDiscount)));
             IdentitiesAndDiscounts actual = dataFetcher.getIdentitiesAndOptionalDiscounts(request, true).block();
             verify(identityService).getBulkIdentities(request);
-            verify(discountService).getBulkSimpleDiscounts(true);
+            verify(discountService).getBulkSimpleDiscounts();
             assertNotNull(actual);
             assertNotNull(actual.identities());
             assertEquals(1, actual.identities().size());
@@ -77,7 +75,7 @@ public class DataFetcherTest implements TestConstants {
             when(identityService.getBulkIdentities(request)).thenReturn(Mono.just(identityList));
             IdentitiesAndDiscounts actual = dataFetcher.getIdentitiesAndOptionalDiscounts(request, false).block();
             verify(identityService).getBulkIdentities(request);
-            verify(discountService, times(0)).getBulkSimpleDiscounts(true);
+            verify(discountService, times(0)).getBulkSimpleDiscounts();
             assertNotNull(actual);
             assertNotNull(actual.identities());
             assertEquals(1, actual.identities().size());

--- a/src/test/java/com/facts/financial_facts_service/services/DiscountServiceTest.java
+++ b/src/test/java/com/facts/financial_facts_service/services/DiscountServiceTest.java
@@ -95,10 +95,10 @@ public class DiscountServiceTest implements TestConstants {
 
         @Test
         public void testGetBulkActiveSimpleDiscounts() {
-            when(discountRepository.findAllActiveSimpleDiscounts())
+            when(discountRepository.findAllSimpleDiscounts())
                     .thenReturn(List.of(activeSimpleDiscount));
             List<SimpleDiscount> actual =
-                    discountService.getBulkSimpleDiscounts(true).block();
+                    discountService.getBulkSimpleDiscounts().block();
             assertNotNull(actual);
             assertEquals(1, actual.size());
             assertEquals(activeSimpleDiscount, actual.get(0));
@@ -109,7 +109,7 @@ public class DiscountServiceTest implements TestConstants {
             when(discountRepository.findAllSimpleDiscounts())
                     .thenReturn(List.of(simpleDiscount));
             List<SimpleDiscount> actual =
-                    discountService.getBulkSimpleDiscounts(false).block();
+                    discountService.getBulkSimpleDiscounts().block();
             assertNotNull(actual);
             assertEquals(1, actual.size());
             assertEquals(simpleDiscount, actual.get(0));
@@ -117,10 +117,10 @@ public class DiscountServiceTest implements TestConstants {
 
         @Test
         public void testGetBulkActiveDiscountsDataAccessError() {
-            when(discountRepository.findAllActiveSimpleDiscounts())
+            when(discountRepository.findAllSimpleDiscounts())
                     .thenThrow(mock(DataAccessException.class));
             assertThrows(DiscountOperationException.class, () ->
-                    discountService.getBulkSimpleDiscounts(true).block());
+                    discountService.getBulkSimpleDiscounts().block());
         }
 
         @Test
@@ -128,7 +128,7 @@ public class DiscountServiceTest implements TestConstants {
             when(discountRepository.findAllSimpleDiscounts())
                     .thenThrow(mock(DataAccessException.class));
             assertThrows(DiscountOperationException.class, () ->
-                    discountService.getBulkSimpleDiscounts(false).block());
+                    discountService.getBulkSimpleDiscounts().block());
         }
     }
 


### PR DESCRIPTION
- Add debt years to StickerPriceInput
- Return inactive discounts with bulk discount
- Add copyable interface to clean discount service
- Added periodic data sorting while fetching discounts
- Add debt years to StickerPriceInput
- Return inactive discounts with bulk discount
- Add copyable interface to clean discount service
- Added periodic data sorting while fetching discounts
- added FMP attribution